### PR TITLE
Add support for 1.8V-powered devices

### DIFF
--- a/esphome/components/bme680_bsec/__init__.py
+++ b/esphome/components/bme680_bsec/__init__.py
@@ -11,6 +11,7 @@ MULTI_CONF = True
 CONF_BME680_BSEC_ID = "bme680_bsec_id"
 CONF_TEMPERATURE_OFFSET = "temperature_offset"
 CONF_IAQ_MODE = "iaq_mode"
+CONF_SUPPLY_VOLTAGE = "supply_voltage"
 CONF_SAMPLE_RATE = "sample_rate"
 CONF_STATE_SAVE_INTERVAL = "state_save_interval"
 
@@ -20,6 +21,12 @@ IAQMode = bme680_bsec_ns.enum("IAQMode")
 IAQ_MODE_OPTIONS = {
     "STATIC": IAQMode.IAQ_MODE_STATIC,
     "MOBILE": IAQMode.IAQ_MODE_MOBILE,
+}
+
+SupplyVoltage = bme680_bsec_ns.enum("SupplyVoltage")
+SUPPLY_VOLTAGE_OPTIONS = {
+    "1.8V": SupplyVoltage.SUPPLY_VOLTAGE_1V8,
+    "3.3V": SupplyVoltage.SUPPLY_VOLTAGE_3V3,
 }
 
 SampleRate = bme680_bsec_ns.enum("SampleRate")
@@ -39,6 +46,9 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_TEMPERATURE_OFFSET, default=0): cv.temperature,
             cv.Optional(CONF_IAQ_MODE, default="STATIC"): cv.enum(
                 IAQ_MODE_OPTIONS, upper=True
+            ),
+            cv.Optional(CONF_SUPPLY_VOLTAGE, default="3.3V"): cv.enum(
+                SUPPLY_VOLTAGE_OPTIONS, upper=True
             ),
             cv.Optional(CONF_SAMPLE_RATE, default="LP"): cv.enum(
                 SAMPLE_RATE_OPTIONS, upper=True
@@ -67,6 +77,7 @@ async def to_code(config):
     cg.add(var.set_device_id(str(config[CONF_ID])))
     cg.add(var.set_temperature_offset(config[CONF_TEMPERATURE_OFFSET]))
     cg.add(var.set_iaq_mode(config[CONF_IAQ_MODE]))
+    cg.add(var.set_supply_voltage(config[CONF_SUPPLY_VOLTAGE]))
     cg.add(var.set_sample_rate(config[CONF_SAMPLE_RATE]))
     cg.add(
         var.set_state_save_interval(config[CONF_STATE_SAVE_INTERVAL].total_milliseconds)

--- a/esphome/components/bme680_bsec/bme680_bsec.cpp
+++ b/esphome/components/bme680_bsec/bme680_bsec.cpp
@@ -52,17 +52,35 @@ void BME680BSECComponent::setup() {
 
 void BME680BSECComponent::set_config_() {
   if (this->sample_rate_ == SAMPLE_RATE_ULP) {
-    const uint8_t config[] = {
+    if (this->supply_voltage_ == SUPPLY_VOLTAGE_3V3) {
+      const uint8_t config[] = {
 #include "config/generic_33v_300s_28d/bsec_iaq.txt"
-    };
-    this->bsec_status_ =
+      };
+      this->bsec_status_ =
         bsec_set_configuration(config, BSEC_MAX_PROPERTY_BLOB_SIZE, this->work_buffer_, sizeof(this->work_buffer_));
-  } else {
-    const uint8_t config[] = {
+    }
+    else {  // SUPPLY_VOLTAGE_1V8
+      const uint8_t config[] = {
+#include "config/generic_18v_300s_28d/bsec_iaq.txt"
+      };
+      this->bsec_status_ =
+        bsec_set_configuration(config, BSEC_MAX_PROPERTY_BLOB_SIZE, this->work_buffer_, sizeof(this->work_buffer_));
+    }
+  } else {  // SAMPLE_RATE_LP
+    if (this->supply_voltage_ == SUPPLY_VOLTAGE_3V3) {
+      const uint8_t config[] = {
 #include "config/generic_33v_3s_28d/bsec_iaq.txt"
-    };
-    this->bsec_status_ =
+      };
+      this->bsec_status_ =
         bsec_set_configuration(config, BSEC_MAX_PROPERTY_BLOB_SIZE, this->work_buffer_, sizeof(this->work_buffer_));
+    }
+    else {  // SUPPLY_VOLTAGE_1V8
+      const uint8_t config[] = {
+#include "config/generic_18v_3s_28d/bsec_iaq.txt"
+      };
+      this->bsec_status_ =
+        bsec_set_configuration(config, BSEC_MAX_PROPERTY_BLOB_SIZE, this->work_buffer_, sizeof(this->work_buffer_));
+    }
   }
 }
 
@@ -145,6 +163,7 @@ void BME680BSECComponent::dump_config() {
 
   ESP_LOGCONFIG(TAG, "  Temperature Offset: %.2f", this->temperature_offset_);
   ESP_LOGCONFIG(TAG, "  IAQ Mode: %s", this->iaq_mode_ == IAQ_MODE_STATIC ? "Static" : "Mobile");
+  ESP_LOGCONFIG(TAG, "  Supply Voltage: %sV", this->supply_voltage_ == SUPPLY_VOLTAGE_3V3 ? "3.3" : "1.8");
   ESP_LOGCONFIG(TAG, "  Sample Rate: %s", BME680_BSEC_SAMPLE_RATE_LOG(this->sample_rate_));
   ESP_LOGCONFIG(TAG, "  State Save Interval: %ims", this->state_save_interval_ms_);
 

--- a/esphome/components/bme680_bsec/bme680_bsec.h
+++ b/esphome/components/bme680_bsec/bme680_bsec.h
@@ -21,6 +21,11 @@ enum IAQMode {
   IAQ_MODE_MOBILE = 1,
 };
 
+enum SupplyVoltage {
+  SUPPLY_VOLTAGE_3V3 = 0,
+  SUPPLY_VOLTAGE_1V8 = 1,
+};
+
 enum SampleRate {
   SAMPLE_RATE_LP = 0,
   SAMPLE_RATE_ULP = 1,
@@ -35,6 +40,7 @@ class BME680BSECComponent : public Component, public i2c::I2CDevice {
   void set_temperature_offset(float offset) { this->temperature_offset_ = offset; }
   void set_iaq_mode(IAQMode iaq_mode) { this->iaq_mode_ = iaq_mode; }
   void set_state_save_interval(uint32_t interval) { this->state_save_interval_ms_ = interval; }
+  void set_supply_voltage(SupplyVoltage supply_voltage) { this->supply_voltage_ = supply_voltage; }
 
   void set_sample_rate(SampleRate sample_rate) { this->sample_rate_ = sample_rate; }
   void set_temperature_sample_rate(SampleRate sample_rate) { this->temperature_sample_rate_ = sample_rate; }
@@ -109,6 +115,7 @@ class BME680BSECComponent : public Component, public i2c::I2CDevice {
   std::string device_id_;
   float temperature_offset_{0};
   IAQMode iaq_mode_{IAQ_MODE_STATIC};
+  SupplyVoltage supply_voltage_;
 
   SampleRate sample_rate_{SAMPLE_RATE_LP};  // Core/gas sample rate
   SampleRate temperature_sample_rate_{SAMPLE_RATE_DEFAULT};


### PR DESCRIPTION
# What does this implement/fix?

The BME680 sensor can be powered from 1.71V to 3.6V. BOSCH provides different configuration arrays for the BSEC library configuration, based on the sensor supply voltage. The Pimoroni PIM357 breakout module for BME680 (https://shop.pimoroni.com/products/bme680-breakout) powers the sensor at 1.8V, and using the 3.3V config arrays results in bad readings for the IAQ value.
This adds support for configuring the supply voltage of the BME680 sensor, defaulting to 3.3V

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
bme680_bsec:
  id: bme680_interno
  i2c_id: "i2cbus_bme"
  address: 0x77
  supply_voltage: 1.8v
  sample_rate: ulp
  temperature_offset: 2.9

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
